### PR TITLE
Refactor FigTree to be ENV-agnostic

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -20,7 +20,9 @@ func TestOptionsEnv(t *testing.T) {
 	}()
 
 	os.Clearenv()
-	err := LoadAllConfigs("figtree.yml", &opts)
+
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	got := []string{}
@@ -55,8 +57,10 @@ func TestOptionsNamedEnv(t *testing.T) {
 	}()
 
 	os.Clearenv()
-	fig := NewFigTree()
+
+	fig := newFigTreeFromEnv()
 	fig.EnvPrefix = "TEST"
+
 	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
@@ -87,7 +91,9 @@ func TestBuiltinEnv(t *testing.T) {
 	defer os.Chdir("..")
 
 	os.Clearenv()
-	err := LoadAllConfigs("figtree.yml", &opts)
+
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	got := []string{}

--- a/exec_test.go
+++ b/exec_test.go
@@ -35,7 +35,8 @@ func TestOptionsExecConfigD3(t *testing.T) {
 		Bool1:  BoolOption{"exec.yml", true, true},
 	}
 
-	err := LoadAllConfigs("exec.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -65,7 +66,8 @@ func TestOptionsExecConfigD2(t *testing.T) {
 		Bool1:  BoolOption{"exec.yml", true, false},
 	}
 
-	err := LoadAllConfigs("exec.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -92,7 +94,8 @@ func TestOptionsExecConfigD1(t *testing.T) {
 		Bool1:  BoolOption{"exec.yml", true, true},
 	}
 
-	err := LoadAllConfigs("exec.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -125,7 +128,8 @@ func TestBuiltinExecConfigD3(t *testing.T) {
 		Bool1:  true,
 	}
 
-	err := LoadAllConfigs("exec.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -157,7 +161,8 @@ func TestBuiltinExecConfigD2(t *testing.T) {
 		Bool1: true,
 	}
 
-	err := LoadAllConfigs("exec.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -184,7 +189,8 @@ func TestBuiltinExecConfigD1(t *testing.T) {
 		Bool1:  true,
 	}
 
-	err := LoadAllConfigs("exec.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }

--- a/figtree.go
+++ b/figtree.go
@@ -29,24 +29,20 @@ type Logger interface {
 var Log Logger = logging.MustGetLogger("figtree")
 
 type FigTree struct {
+	Home      string
+	WorkDir   string
 	ConfigDir string
 	Defaults  interface{}
 	EnvPrefix string
 	stop      bool
 }
 
-func NewFigTree() *FigTree {
+func NewFigTree(home, workDir, envPrefix string) *FigTree {
 	return &FigTree{
-		EnvPrefix: "FIGTREE",
+		Home:      home,
+		WorkDir:   workDir,
+		EnvPrefix: envPrefix,
 	}
-}
-
-func LoadAllConfigs(configFile string, options interface{}) error {
-	return NewFigTree().LoadAllConfigs(configFile, options)
-}
-
-func LoadConfig(configFile string, options interface{}) error {
-	return NewFigTree().LoadConfig(configFile, options)
 }
 
 func (f *FigTree) LoadAllConfigs(configFile string, options interface{}) error {
@@ -57,7 +53,7 @@ func (f *FigTree) LoadAllConfigs(configFile string, options interface{}) error {
 		configFile = path.Join(f.ConfigDir, configFile)
 	}
 
-	paths := FindParentPaths(configFile)
+	paths := FindParentPaths(f.Home, f.WorkDir, configFile)
 	paths = append([]string{fmt.Sprintf("/etc/%s", configFile)}, paths...)
 
 	// iterate paths in reverse
@@ -131,12 +127,7 @@ func (f *FigTree) LoadConfigBytes(config []byte, source string, options interfac
 }
 
 func (f *FigTree) LoadConfig(file string, options interface{}) (err error) {
-	basePath, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	rel, err := filepath.Rel(basePath, file)
+	rel, err := filepath.Rel(f.WorkDir, file)
 	if err != nil {
 		rel = file
 	}

--- a/figtree_test.go
+++ b/figtree_test.go
@@ -31,6 +31,11 @@ func init() {
 	logging.SetLevel(logging.NOTICE, "")
 }
 
+func newFigTreeFromEnv() *FigTree {
+	cwd, _ := os.Getwd()
+	return NewFigTree(os.Getenv("HOME"), cwd, "FIGTREE")
+}
+
 type TestOptions struct {
 	String1    StringOption     `json:"str1,omitempty" yaml:"str1,omitempty"`
 	LeaveEmpty StringOption     `json:"leave-empty,omitempty" yaml:"leave-empty,omitempty"`
@@ -81,7 +86,8 @@ func TestOptionsLoadConfigD3(t *testing.T) {
 		Bool1:  BoolOption{"figtree.yml", true, true},
 	}
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -113,7 +119,8 @@ func TestOptionsLoadConfigD2(t *testing.T) {
 		Bool1:  BoolOption{"figtree.yml", true, false},
 	}
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -142,7 +149,8 @@ func TestOptionsLoadConfigD1(t *testing.T) {
 		Bool1:  BoolOption{"figtree.yml", true, true},
 	}
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -152,7 +160,8 @@ func TestOptionsCorrupt(t *testing.T) {
 	os.Chdir("d1")
 	defer os.Chdir("..")
 
-	err := LoadAllConfigs("corrupt.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("corrupt.yml", &opts)
 	assert.NotNil(t, err)
 }
 
@@ -186,7 +195,8 @@ func TestBuiltinLoadConfigD3(t *testing.T) {
 		Bool1:  true,
 	}
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -220,7 +230,8 @@ func TestBuiltinLoadConfigD2(t *testing.T) {
 		Bool1: true,
 	}
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -249,7 +260,8 @@ func TestBuiltinLoadConfigD1(t *testing.T) {
 		Bool1:  true,
 	}
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -259,7 +271,8 @@ func TestBuiltinCorrupt(t *testing.T) {
 	os.Chdir("d1")
 	defer os.Chdir("..")
 
-	err := LoadAllConfigs("corrupt.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("corrupt.yml", &opts)
 	assert.NotNil(t, err)
 }
 
@@ -296,7 +309,8 @@ func TestOptionsLoadConfigDefaults(t *testing.T) {
 		Bool1:  BoolOption{"figtree.yml", true, false},
 	}
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	require.Exactly(t, expected, opts)
 }

--- a/kingpin_test.go
+++ b/kingpin_test.go
@@ -20,7 +20,8 @@ func TestCommandLine(t *testing.T) {
 	os.Chdir("d1/d2/d3")
 	defer os.Chdir("../../..")
 
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	app := kingpin.New("test", "testing")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -14,7 +14,8 @@ func TestOptionsMarshalYAML(t *testing.T) {
 	opts := TestOptions{}
 	os.Chdir("d1/d2/d3")
 	defer os.Chdir("../../..")
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	StringifyValue = true
@@ -50,7 +51,8 @@ func TestOptionsMarshalJSON(t *testing.T) {
 	opts := TestOptions{}
 	os.Chdir("d1/d2/d3")
 	defer os.Chdir("../../..")
-	err := LoadAllConfigs("figtree.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	StringifyValue = true

--- a/overwrite_test.go
+++ b/overwrite_test.go
@@ -35,7 +35,8 @@ func TestOptionsOverwriteConfigD3(t *testing.T) {
 		Bool1:  BoolOption{"../overwrite.yml", true, false},
 	}
 
-	err := LoadAllConfigs("overwrite.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -64,7 +65,8 @@ func TestOptionsOverwriteConfigD2(t *testing.T) {
 		Bool1:  BoolOption{"overwrite.yml", true, false},
 	}
 
-	err := LoadAllConfigs("overwrite.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -93,7 +95,8 @@ func TestBuiltinOverwriteConfigD3(t *testing.T) {
 		Bool1:  true,
 	}
 
-	err := LoadAllConfigs("overwrite.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -124,7 +127,8 @@ func TestBuiltinOverwriteConfigD2(t *testing.T) {
 		Bool1: true,
 	}
 
-	err := LoadAllConfigs("overwrite.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }

--- a/stop_test.go
+++ b/stop_test.go
@@ -32,7 +32,8 @@ func TestOptionsStopConfigD3(t *testing.T) {
 		Bool1:  BoolOption{"stop.yml", true, true},
 	}
 
-	err := LoadAllConfigs("stop.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -59,7 +60,8 @@ func TestOptionsStopConfigD2(t *testing.T) {
 		Bool1:  BoolOption{"stop.yml", true, false},
 	}
 
-	err := LoadAllConfigs("stop.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -89,7 +91,8 @@ func TestBuiltinStopConfigD3(t *testing.T) {
 		Bool1:  true,
 	}
 
-	err := LoadAllConfigs("stop.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -116,7 +119,8 @@ func TestBuiltinStopConfigD2(t *testing.T) {
 		Bool1:  false,
 	}
 
-	err := LoadAllConfigs("stop.yml", &opts)
+	fig := newFigTreeFromEnv()
+	err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }

--- a/utils.go
+++ b/utils.go
@@ -4,24 +4,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
-func homedir() string {
-	if runtime.GOOS == "windows" {
-		return os.Getenv("USERPROFILE")
-	}
-	return os.Getenv("HOME")
-}
-
-func FindParentPaths(fileName string) []string {
-	cwd, _ := os.Getwd()
-
+func FindParentPaths(homedir, cwd, fileName string) []string {
 	paths := make([]string, 0)
 
 	// special case if homedir is not in current path then check there anyway
-	homedir := homedir()
 	if !strings.HasPrefix(cwd, homedir) {
 		file := path.Join(homedir, fileName)
 		if _, err := os.Stat(file); err == nil {


### PR DESCRIPTION
This PR removes reliance on `os.Getenv` and `os.Getwd` and allows the caller to specify it instead. Since it is a required field, they have been added to `NewFigTree`'s function signature.

Helper methods `LoadAllConfigs` and `LoadConfig` were removed to ensure no calls using ENV were used outside of `figtree`'s tests.