### PR TITLE
Refactor out Setenv and Unsetenv

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -22,8 +22,10 @@ func TestOptionsEnv(t *testing.T) {
 	os.Clearenv()
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	changeSet, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
+
+	ApplyChangeSet(changeSet)
 
 	got := []string{}
 	for _, env := range os.Environ() {
@@ -61,8 +63,10 @@ func TestOptionsNamedEnv(t *testing.T) {
 	fig := newFigTreeFromEnv()
 	fig.EnvPrefix = "TEST"
 
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	changeSet, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
+
+	ApplyChangeSet(changeSet)
 
 	got := []string{}
 	for _, env := range os.Environ() {
@@ -93,8 +97,10 @@ func TestBuiltinEnv(t *testing.T) {
 	os.Clearenv()
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	changeSet, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
+
+	ApplyChangeSet(changeSet)
 
 	got := []string{}
 	for _, env := range os.Environ() {

--- a/exec_test.go
+++ b/exec_test.go
@@ -36,7 +36,7 @@ func TestOptionsExecConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("exec.yml", &opts)
+	_, err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -67,7 +67,7 @@ func TestOptionsExecConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("exec.yml", &opts)
+	_, err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -95,7 +95,7 @@ func TestOptionsExecConfigD1(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("exec.yml", &opts)
+	_, err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -129,7 +129,7 @@ func TestBuiltinExecConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("exec.yml", &opts)
+	_, err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -162,7 +162,7 @@ func TestBuiltinExecConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("exec.yml", &opts)
+	_, err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -190,7 +190,7 @@ func TestBuiltinExecConfigD1(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("exec.yml", &opts)
+	_, err := fig.LoadAllConfigs("exec.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }

--- a/figtree_test.go
+++ b/figtree_test.go
@@ -87,7 +87,7 @@ func TestOptionsLoadConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -120,7 +120,7 @@ func TestOptionsLoadConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -150,7 +150,7 @@ func TestOptionsLoadConfigD1(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -161,7 +161,7 @@ func TestOptionsCorrupt(t *testing.T) {
 	defer os.Chdir("..")
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("corrupt.yml", &opts)
+	_, err := fig.LoadAllConfigs("corrupt.yml", &opts)
 	assert.NotNil(t, err)
 }
 
@@ -196,7 +196,7 @@ func TestBuiltinLoadConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -231,7 +231,7 @@ func TestBuiltinLoadConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -261,7 +261,7 @@ func TestBuiltinLoadConfigD1(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -272,7 +272,7 @@ func TestBuiltinCorrupt(t *testing.T) {
 	defer os.Chdir("..")
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("corrupt.yml", &opts)
+	_, err := fig.LoadAllConfigs("corrupt.yml", &opts)
 	assert.NotNil(t, err)
 }
 
@@ -310,7 +310,7 @@ func TestOptionsLoadConfigDefaults(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 	require.Exactly(t, expected, opts)
 }

--- a/kingpin_test.go
+++ b/kingpin_test.go
@@ -21,7 +21,7 @@ func TestCommandLine(t *testing.T) {
 	defer os.Chdir("../../..")
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	app := kingpin.New("test", "testing")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -15,7 +15,7 @@ func TestOptionsMarshalYAML(t *testing.T) {
 	os.Chdir("d1/d2/d3")
 	defer os.Chdir("../../..")
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	StringifyValue = true
@@ -52,7 +52,7 @@ func TestOptionsMarshalJSON(t *testing.T) {
 	os.Chdir("d1/d2/d3")
 	defer os.Chdir("../../..")
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("figtree.yml", &opts)
+	_, err := fig.LoadAllConfigs("figtree.yml", &opts)
 	assert.Nil(t, err)
 
 	StringifyValue = true

--- a/overwrite_test.go
+++ b/overwrite_test.go
@@ -36,7 +36,7 @@ func TestOptionsOverwriteConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("overwrite.yml", &opts)
+	_, err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -66,7 +66,7 @@ func TestOptionsOverwriteConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("overwrite.yml", &opts)
+	_, err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -96,7 +96,7 @@ func TestBuiltinOverwriteConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("overwrite.yml", &opts)
+	_, err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -128,7 +128,7 @@ func TestBuiltinOverwriteConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("overwrite.yml", &opts)
+	_, err := fig.LoadAllConfigs("overwrite.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }

--- a/stop_test.go
+++ b/stop_test.go
@@ -33,7 +33,7 @@ func TestOptionsStopConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("stop.yml", &opts)
+	_, err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -61,7 +61,7 @@ func TestOptionsStopConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("stop.yml", &opts)
+	_, err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -92,7 +92,7 @@ func TestBuiltinStopConfigD3(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("stop.yml", &opts)
+	_, err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }
@@ -120,7 +120,7 @@ func TestBuiltinStopConfigD2(t *testing.T) {
 	}
 
 	fig := newFigTreeFromEnv()
-	err := fig.LoadAllConfigs("stop.yml", &opts)
+	_, err := fig.LoadAllConfigs("stop.yml", &opts)
 	assert.Nil(t, err)
 	assert.Exactly(t, expected, opts)
 }


### PR DESCRIPTION
`PopulateEnv` returns a `map[string]*string` instead of calling `os.Setenv` and `os.Unsetenv`:

Users can retain original behavior by applying the changes via `figtree.ApplyChangeSet(changeSet)`