### PR TITLE
prevent calling reflect.MakeSlice on Array type

### DIFF
--- a/figtree.go
+++ b/figtree.go
@@ -1013,8 +1013,15 @@ func (m *Merger) mergeMaps(ov, nv reflect.Value) {
 }
 
 func (m *Merger) mergeArrays(ov, nv reflect.Value) reflect.Value {
-	cp := reflect.MakeSlice(ov.Type(), ov.Len(), ov.Len())
-	reflect.Copy(cp, ov)
+	var cp reflect.Value
+	switch ov.Type().Kind() {
+	case reflect.Slice:
+		cp = reflect.MakeSlice(ov.Type(), ov.Len(), ov.Len())
+		reflect.Copy(cp, ov)
+	case reflect.Array:
+		// arrays are copied, not passed by reference, so we dont need to copy
+		cp = ov
+	}
 	var zero interface{}
 Outer:
 	for ni := 0; ni < nv.Len(); ni++ {

--- a/figtree_test.go
+++ b/figtree_test.go
@@ -1852,3 +1852,27 @@ func TestMergeCopySlice(t *testing.T) {
 	assert.Equal(t, []string{"updated"}, stuffers[0].Stuff)
 	assert.Equal(t, []string{"common"}, stuffers[1].Stuff)
 }
+
+func TestMergeCopyArray(t *testing.T) {
+	type stuffer = struct {
+		Stuff [2]string
+	}
+
+	stuffers := []*stuffer{}
+	common := &stuffer{Stuff: [2]string{"common"}}
+
+	stuff1 := &stuffer{Stuff: [2]string{}}
+	stuff2 := &stuffer{Stuff: [2]string{}}
+
+	for _, stuff := range []*stuffer{stuff1, stuff2} {
+		Merge(stuff, common)
+		stuffers = append(stuffers, stuff)
+	}
+
+	assert.Equal(t, [2]string{"common", ""}, stuffers[0].Stuff)
+	assert.Equal(t, [2]string{"common", ""}, stuffers[1].Stuff)
+
+	stuffers[0].Stuff[0] = "updated"
+	assert.Equal(t, [2]string{"updated", ""}, stuffers[0].Stuff)
+	assert.Equal(t, [2]string{"common", ""}, stuffers[1].Stuff)
+}


### PR DESCRIPTION
mergeArrays is called on both Slice and Array, so #11 ended up causing an issue when trying to call MakeSlice on Array type.