### PR TITLE
fix map/struct iteration when `!!merge` keys are used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	emperror.dev/errors v0.8.1
-	github.com/coryb/walky v0.0.0-20220701203230-2fd8cacacc26
+	github.com/coryb/walky v0.0.0-20220713063916-a85dff598ab4
 	github.com/fatih/camelcase v1.0.1-0.20181010234014-9db1b65eb38b
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/coryb/walky v0.0.0-20220701203230-2fd8cacacc26 h1:S2aHSqH6kQOkYBriNK0as7DPwLmDaW5vLbSGm+PKfG8=
-github.com/coryb/walky v0.0.0-20220701203230-2fd8cacacc26/go.mod h1:7xR3ILc1FaTPNsVi9csjhYRL9Jk8T/GvqpY8I1I6j4o=
+github.com/coryb/walky v0.0.0-20220713063916-a85dff598ab4 h1:YN5pkzOCRjVEM7lgEy2Y/hhWXLvfOMPIpA9HQ3u/sDU=
+github.com/coryb/walky v0.0.0-20220713063916-a85dff598ab4/go.mod h1:7xR3ILc1FaTPNsVi9csjhYRL9Jk8T/GvqpY8I1I6j4o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
when iterating over yaml maps we have to special case the !!merge
keys and iterate over the value. The value may be a sequence of maps.
This logic has all be encapsulated in the walky.RangeMap function:
https://github.com/coryb/walky/pull/4