### PR TITLE
fix yaml `!!merge` usage with duplicate keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	emperror.dev/errors v0.8.1
-	github.com/coryb/walky v0.0.0-20220713063916-a85dff598ab4
+	github.com/coryb/walky v0.0.0-20220714002555-14fc067187cd
 	github.com/fatih/camelcase v1.0.1-0.20181010234014-9db1b65eb38b
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/coryb/walky v0.0.0-20220713063916-a85dff598ab4 h1:YN5pkzOCRjVEM7lgEy2Y/hhWXLvfOMPIpA9HQ3u/sDU=
-github.com/coryb/walky v0.0.0-20220713063916-a85dff598ab4/go.mod h1:7xR3ILc1FaTPNsVi9csjhYRL9Jk8T/GvqpY8I1I6j4o=
+github.com/coryb/walky v0.0.0-20220714002555-14fc067187cd h1:rwrdQHBy0Ag8ugdZXQyU12isSRH5wM5pGYoTD2Z4UEU=
+github.com/coryb/walky v0.0.0-20220714002555-14fc067187cd/go.mod h1:7xR3ILc1FaTPNsVi9csjhYRL9Jk8T/GvqpY8I1I6j4o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
If we have:
```yaml
defs:
  - &mydef {a: 1, b: 2}
stuff:
  <<: *mydef
  a:
```
we should end up with `a: !!null` and `b: 2` where `a: 1` is
skipped from the mydef merge.  This is consistent with how yaml.Unmarshal
works with duplication keys with !!merge.  The fix is upstream in walky.

This also fixes an issue with backwards compat changes for arrays.
Arrays should be allowed to have duplicate values if those dups are
coming from the original array source, and not from extra merged in
configs.

Also fixed is an edge-case where some options were not being seen
as empty when derived from `!!null` yaml fields.