### PR TITLE
fix overwrite with empty array

### DIFF
--- a/figtree.go
+++ b/figtree.go
@@ -1654,7 +1654,7 @@ func (m *Merger) mergeArrays(dst reflect.Value, src mergeSource, overwrite bool)
 	}
 
 	var zero interface{}
-	changed := false
+	changed := overwrite
 	err := src.foreach(func(ix int, item mergeSource) error {
 		reflected, _, err := item.reflect()
 		if err != nil {


### PR DESCRIPTION
adding tests to verify overwrite of scalars, arrays and maps with populated and unpopulated values

We were iterating over zero elements, which normally should result in "no changes", but in the overwrite case, we should always report changes.