### PR TITLE
fix merge struct issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,17 +9,15 @@ jobs:
                 go: [ '1.18' ]
                 os: [ 'ubuntu-latest' ]
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Setup go
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@v5
               with:
                 go-version: ${{ matrix.go }}
-            - uses: actions/cache@v2
+            - uses: actions/cache@v4
               with:
                 path: ~/go/pkg/mod
                 key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-                restore-keys: |
-                    ${{ runner.os }}-go-
             - name: Go Test
               run: go test -v ./...
     lint:
@@ -27,10 +25,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Setup go
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@v5
               with:
                 go-version: 1.18
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: install golangci-lint
               run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
             - name: run golangci-lint

--- a/figtree.go
+++ b/figtree.go
@@ -400,10 +400,11 @@ func camelCase(name string) string {
 }
 
 type Merger struct {
-	sourceFile  string
-	preserveMap map[string]struct{}
-	Config      ConfigOptions `json:"config,omitempty" yaml:"config,omitempty"`
-	ignore      []string
+	sourceFile   string
+	preserveMap  map[string]struct{}
+	preserveTags map[string]struct{}
+	Config       ConfigOptions `json:"config,omitempty" yaml:"config,omitempty"`
+	ignore       []string
 }
 
 type MergeOption func(*Merger)
@@ -422,10 +423,23 @@ func PreserveMap(keys ...string) MergeOption {
 	}
 }
 
+func PreserveTags(names ...string) MergeOption {
+	return func(m *Merger) {
+		for _, tag := range names {
+			m.preserveTags[tag] = struct{}{}
+		}
+	}
+}
+
 func NewMerger(options ...MergeOption) *Merger {
 	m := &Merger{
 		sourceFile:  "merge",
 		preserveMap: make(map[string]struct{}),
+		preserveTags: map[string]struct{}{
+			"json":    {},
+			"yaml":    {},
+			"figtree": {},
+		},
 	}
 	for _, opt := range options {
 		opt(m)
@@ -536,6 +550,50 @@ func mergeOptions(a reflect.Type, b reflect.Type) (reflect.Value, bool) {
 	return reflect.Value{}, false
 }
 
+func (m *Merger) mergeTags(a reflect.StructField, b reflect.StructField) string {
+	allTags := []string{}
+	for k := range m.preserveTags {
+		allTags = append(allTags, k)
+	}
+	var resultTag []string
+	sort.Strings(allTags)
+	for _, tag := range allTags {
+		aTag, aOk := a.Tag.Lookup(tag)
+		bTag, bOk := b.Tag.Lookup(tag)
+		switch {
+		case aOk && bOk:
+			// if both defined, pick the first one
+			resultTag = append(resultTag, fmt.Sprintf("%s:%q", tag, aTag))
+		case aOk:
+			resultTag = append(resultTag, fmt.Sprintf("%s:%q", tag, aTag))
+		case bOk:
+			resultTag = append(resultTag, fmt.Sprintf("%s:%q", tag, bTag))
+		}
+	}
+	return strings.Join(resultTag, " ")
+}
+
+// findField will look for the field in the map.  It will first look for
+// the field name as defined by CanonicalFieldName, then it will look for
+// a field based on the yaml tag name.  This helps ensure that we dont add
+// duplicate fields based on either struct field name or the yaml tag name,
+// both of which will cause failures.
+func findField(fields map[string]reflect.StructField, field reflect.StructField) (key string, found reflect.StructField, ok bool) {
+	fieldName := CanonicalFieldName(field)
+	if f, found := fields[fieldName]; found {
+		return fieldName, f, true
+	}
+
+	yamlName := yamlFieldName(field)
+	for k, f := range fields {
+		if yamlName == yamlFieldName(f) {
+			return k, f, true
+		}
+	}
+
+	return "", reflect.StructField{}, false
+}
+
 func (m *Merger) makeMergeStruct(values ...reflect.Value) reflect.Value {
 	foundFields := map[string]reflect.StructField{}
 	for i := 0; i < len(values); i++ {
@@ -554,8 +612,21 @@ func (m *Merger) makeMergeStruct(values ...reflect.Value) reflect.Value {
 				}
 
 				field.Name = CanonicalFieldName(field)
+				if fieldKey, f, ok := findField(foundFields, field); ok {
+					newTag := m.mergeTags(f, field)
+					if newTag != string(f.Tag) {
+						f.Tag = reflect.StructTag(newTag)
+						foundFields[fieldKey] = f
+					}
 
-				if f, ok := foundFields[field.Name]; ok {
+					// the canonical name is influenced by the `figtree` tag
+					// so make sure the merged field has the correct name after
+					// merging the tags.
+					if fieldName := CanonicalFieldName(f); f.Name != fieldName {
+						f.Name = fieldName
+						foundFields[fieldKey] = f
+					}
+
 					if f.Type.Kind() == reflect.Struct && field.Type.Kind() == reflect.Struct {
 						if fName, fieldName := f.Type.Name(), field.Type.Name(); fName == "" || fieldName == "" || fName != fieldName {
 							// do we have two options?
@@ -563,13 +634,13 @@ func (m *Merger) makeMergeStruct(values ...reflect.Value) reflect.Value {
 								// we have two fields with the same name and they are both options, so we need
 								// to merge the existing option with the new one in case they are different
 								f.Type = newval.Type()
-								foundFields[field.Name] = f
+								foundFields[fieldKey] = f
 							} else {
 								// we have 2 fields with the same name and they are both structs, so we need
 								// to merge the existing struct with the new one in case they are different
 								newval := m.makeMergeStruct(reflect.New(f.Type).Elem(), reflect.New(field.Type).Elem()).Elem()
 								f.Type = newval.Type()
-								foundFields[field.Name] = f
+								foundFields[fieldKey] = f
 							}
 						}
 					}
@@ -608,14 +679,35 @@ func (m *Merger) makeMergeStruct(values ...reflect.Value) reflect.Value {
 					Type: t,
 					Tag:  reflect.StructTag(fmt.Sprintf(`json:"%s" yaml:"%s"`, key.String(), key.String())),
 				}
-				if f, ok := foundFields[field.Name]; ok {
+				// the yaml and json names are just taken directly from the map key
+				if fieldKey, f, ok := findField(foundFields, field); ok {
+					newTag := m.mergeTags(f, field)
+					if newTag != string(f.Tag) {
+						f.Tag = reflect.StructTag(newTag)
+						foundFields[fieldKey] = f
+					}
+					// the canonical name is influenced by the `figtree` tag
+					// so make sure the merged field has the correct name after
+					// merging the tags.
+					if fieldName := CanonicalFieldName(f); f.Name != fieldName {
+						f.Name = fieldName
+						foundFields[fieldKey] = f
+					}
 					if f.Type.Kind() == reflect.Struct && t.Kind() == reflect.Struct {
 						if fName, tName := f.Type.Name(), t.Name(); fName == "" || tName == "" || fName != tName {
-							// we have 2 fields with the same name and they are both structs, so we need
-							// to merge the existig struct with the new one in case they are different
-							newval := m.makeMergeStruct(reflect.New(f.Type).Elem(), reflect.New(t).Elem()).Elem()
-							f.Type = newval.Type()
-							foundFields[field.Name] = f
+							// do we have two options?
+							if newval, ok := mergeOptions(f.Type, field.Type); ok {
+								// we have two fields with the same name and they are both options, so we need
+								// to merge the existing option with the new one in case they are different
+								f.Type = newval.Type()
+								foundFields[fieldKey] = f
+							} else {
+								// we have 2 fields with the same name and they are both structs, so we need
+								// to merge the existig struct with the new one in case they are different
+								newval := m.makeMergeStruct(reflect.New(f.Type).Elem(), reflect.New(t).Elem()).Elem()
+								f.Type = newval.Type()
+								foundFields[fieldKey] = f
+							}
 						}
 					}
 					// field already found, skip
@@ -627,8 +719,23 @@ func (m *Merger) makeMergeStruct(values ...reflect.Value) reflect.Value {
 	}
 
 	fields := []reflect.StructField{}
+	seen := map[string]reflect.StructField{}
+	yamlSeen := map[string]reflect.StructField{}
 	for _, value := range foundFields {
 		fields = append(fields, value)
+		if prev, ok := seen[value.Name]; ok {
+			// we have a duplicate field name, this should not happen
+			// but if it does, we will just skip it
+			fmt.Fprintf(os.Stderr, "Duplicate field name %q in merge struct.\n\tOld: %s %s `%s`\n\tNew: %s %s `%s`\n", value.Name, prev.Name, prev.Type.String(), prev.Tag, value.Name, value.Type.String(), value.Tag)
+		}
+		seen[value.Name] = value
+		yamlName := yamlTagName(value.Tag)
+		if prev, ok := yamlSeen[yamlName]; yamlName != "" && ok {
+			// we have a duplicate field name, this should not happen
+			// but if it does, we will just skip it
+			fmt.Fprintf(os.Stderr, "Duplicate YAML tag %q in merge struct.\n\tOld: %s %s `%s`\n\tNew: %s %s `%s`\n", yamlName, prev.Name, prev.Type.String(), prev.Tag, value.Name, value.Type.String(), value.Tag)
+		}
+		yamlSeen[yamlName] = value
 	}
 	sort.Slice(fields, func(i, j int) bool {
 		return fields[i].Name < fields[j].Name
@@ -710,14 +817,21 @@ type ConfigOptions struct {
 	Overwrite []string `json:"overwrite,omitempty" yaml:"overwrite,omitempty"`
 }
 
-func yamlFieldName(sf reflect.StructField) string {
-	if tag, ok := sf.Tag.Lookup("yaml"); ok {
+func yamlTagName(tag reflect.StructTag) string {
+	if tag, ok := tag.Lookup("yaml"); ok {
 		// with yaml:"foobar,omitempty"
 		// we just want to the "foobar" part
 		parts := strings.Split(tag, ",")
 		if parts[0] != "" && parts[0] != "-" {
 			return parts[0]
 		}
+	}
+	return ""
+}
+
+func yamlFieldName(sf reflect.StructField) string {
+	if name := yamlTagName(sf.Tag); name != "" {
+		return name
 	}
 	// guess the field name from reversing camel case
 	// so "FooBar" becomes "foo-bar"

--- a/figtree.go
+++ b/figtree.go
@@ -561,10 +561,7 @@ func (m *Merger) mergeTags(a reflect.StructField, b reflect.StructField) string 
 		aTag, aOk := a.Tag.Lookup(tag)
 		bTag, bOk := b.Tag.Lookup(tag)
 		switch {
-		case aOk && bOk:
-			// if both defined, pick the first one
-			resultTag = append(resultTag, fmt.Sprintf("%s:%q", tag, aTag))
-		case aOk:
+		case aOk: // if a has a tag or both have the tag, use a
 			resultTag = append(resultTag, fmt.Sprintf("%s:%q", tag, aTag))
 		case bOk:
 			resultTag = append(resultTag, fmt.Sprintf("%s:%q", tag, bTag))
@@ -725,15 +722,13 @@ func (m *Merger) makeMergeStruct(values ...reflect.Value) reflect.Value {
 		fields = append(fields, value)
 		if prev, ok := seen[value.Name]; ok {
 			// we have a duplicate field name, this should not happen
-			// but if it does, we will just skip it
-			fmt.Fprintf(os.Stderr, "Duplicate field name %q in merge struct.\n\tOld: %s %s `%s`\n\tNew: %s %s `%s`\n", value.Name, prev.Name, prev.Type.String(), prev.Tag, value.Name, value.Type.String(), value.Tag)
+			panic(fmt.Sprintf("Duplicate field name %q in merge struct.\n\tOld: %s %s `%s`\n\tNew: %s %s `%s`\n", value.Name, prev.Name, prev.Type.String(), prev.Tag, value.Name, value.Type.String(), value.Tag))
 		}
 		seen[value.Name] = value
 		yamlName := yamlTagName(value.Tag)
 		if prev, ok := yamlSeen[yamlName]; yamlName != "" && ok {
 			// we have a duplicate field name, this should not happen
-			// but if it does, we will just skip it
-			fmt.Fprintf(os.Stderr, "Duplicate YAML tag %q in merge struct.\n\tOld: %s %s `%s`\n\tNew: %s %s `%s`\n", yamlName, prev.Name, prev.Type.String(), prev.Tag, value.Name, value.Type.String(), value.Tag)
+			panic(fmt.Sprintf("Duplicate YAML tag %q in merge struct.\n\tOld: %s %s `%s`\n\tNew: %s %s `%s`\n", yamlName, prev.Name, prev.Type.String(), prev.Tag, value.Name, value.Type.String(), value.Tag))
 		}
 		yamlSeen[yamlName] = value
 	}

--- a/figtree_test.go
+++ b/figtree_test.go
@@ -3443,3 +3443,23 @@ func TestMergeWithDstStructArg(t *testing.T) {
 	err := Merge(dest, src)
 	require.Error(t, err)
 }
+
+func TestMergeOptionAny(t *testing.T) {
+	input1 := struct {
+		StructField Option[string] `yaml:"struct-field"`
+	}{}
+
+	input2 := struct {
+		StructField Option[any] `yaml:"struct-field"`
+	}{}
+
+	merge := MakeMergeStruct(input1, input2)
+	require.Equal(t, &struct {
+		StructField Option[any] `yaml:"struct-field"`
+	}{}, merge)
+
+	merge = MakeMergeStruct(input2, input1)
+	require.Equal(t, &struct {
+		StructField Option[any] `yaml:"struct-field"`
+	}{}, merge)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -33,5 +33,5 @@ gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473 h1:6D+BvnJ/j6e222UW
 gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473/go.mod h1:N1eN2tsCx0Ydtgjl4cqmbRCsY4/+z4cYDeqwZTk6zog=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e h1:3i3ny04XV6HbZ2N1oIBw1UBYATHAOpo4tfTF83JM3Z0=
+gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
* fix merging for two differnt `Option` types, select the type that both merge types are assignable to (ie `Option[string]` vs `Option[any]`, `Option[any]` will be chosen).
* preserve tags when merging fields
* prefer `figtree:"name=value"` tag for field names.
* prevent duplicate conflicts between yaml names and struct field names.
